### PR TITLE
(1-3)Eメール重複チェック処理の追加

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -3,6 +3,7 @@ package com.example.controller;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -63,7 +64,7 @@ public class AdministratorController {
 	 * @return 管理者登録画面
 	 */
 	@GetMapping("/toInsert")
-	public String toInsert(InsertAdministratorForm form) {
+	public String toInsert(Model model, InsertAdministratorForm form) {
 		return "administrator/insert";
 	}
 
@@ -74,13 +75,17 @@ public class AdministratorController {
 	 * @return ログイン画面へリダイレクト
 	 */
 	@PostMapping("/insert")
-	public String insert(@Validated InsertAdministratorForm form, BindingResult bindingResult) {
+	public String insert(@Validated InsertAdministratorForm form, BindingResult bindingResult, Model model) {
 		if (bindingResult.hasErrors()) {
-			return toInsert(form);
+			return toInsert(model, form);
 		}
 		Administrator administrator = new Administrator();
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
+		if (administratorService.findByMailAddress(administrator.getMailAddress()) != null) {
+			model.addAttribute("notUniqueMail", "メールアドレスが重複しています");
+			return toInsert(model, form);
+		}
 		administratorService.insert(administrator);
 		return "redirect:/";
 	}

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -3,6 +3,8 @@ package com.example.controller;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -61,7 +63,7 @@ public class AdministratorController {
 	 * @return 管理者登録画面
 	 */
 	@GetMapping("/toInsert")
-	public String toInsert() {
+	public String toInsert(InsertAdministratorForm form) {
 		return "administrator/insert";
 	}
 
@@ -72,7 +74,10 @@ public class AdministratorController {
 	 * @return ログイン画面へリダイレクト
 	 */
 	@PostMapping("/insert")
-	public String insert(InsertAdministratorForm form) {
+	public String insert(@Validated InsertAdministratorForm form, BindingResult bindingResult) {
+		if (bindingResult.hasErrors()) {
+			return toInsert(form);
+		}
 		Administrator administrator = new Administrator();
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);

--- a/src/main/java/com/example/form/InsertAdministratorForm.java
+++ b/src/main/java/com/example/form/InsertAdministratorForm.java
@@ -1,5 +1,7 @@
 package com.example.form;
 
+import jakarta.validation.constraints.NotBlank;
+
 /**
  * 管理者情報登録時に使用するフォーム.
  * 
@@ -8,10 +10,13 @@ package com.example.form;
  */
 public class InsertAdministratorForm {
 	/** 名前 */
+	@NotBlank()
 	private String name;
 	/** メールアドレス */
+	@NotBlank()
 	private String mailAddress;
 	/** パスワード */
+	@NotBlank()
 	private String password;
 
 	public String getName() {

--- a/src/main/java/com/example/service/AdministratorService.java
+++ b/src/main/java/com/example/service/AdministratorService.java
@@ -30,6 +30,16 @@ public class AdministratorService {
 	}
 
 	/**
+	 * メールアドレスの重複チェックをします.
+	 * 
+	 * @param  mailAddress メールアドレス
+	 */
+	public Administrator findByMailAddress(String mailAddress) {
+		Administrator administrator = administratorRepository.findByMailAddress(mailAddress);
+		return administrator;
+	}
+
+	/**
 	 * ログインをします.
 	 * 
 	 * @param mailAddress メールアドレス

--- a/src/main/resources/templates/administrator/insert.html
+++ b/src/main/resources/templates/administrator/insert.html
@@ -87,6 +87,11 @@
                       >
                         メールアドレスを入力してください
                       </label>
+                      <label
+                        th:text="${notUniqueMail}"
+                        class="error-messages"
+                      >
+                      </label>
                       <input
                         type="text"
                         name="mailAddress"


### PR DESCRIPTION
Eメール重複チェック処理を追加しました。
管理者登録用のSQLを発行する前に、メールアドレスの重複がないか確認するSQLを発行しています。
重複があった場合は
1.エラーメッセージをリクエストスコープに格納
2.入力画面にフォームを引き継いだままフォワード
します。