### PR TITLE
(1-5)管理者登録時に再確認用パスワードを求める機能を追加

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -80,6 +80,10 @@ public class AdministratorController {
 			return toInsert(model, form);
 		}
 		Administrator administrator = new Administrator();
+		if (!(form.getPassword().equals(form.getPasswordConfirm()))) {
+			model.addAttribute("notConfirmPassword", "確認用パスワードが一致していません");
+			return toInsert(model, form);
+		}
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
 		if (administratorService.findByMailAddress(administrator.getMailAddress()) != null) {

--- a/src/main/java/com/example/form/InsertAdministratorForm.java
+++ b/src/main/java/com/example/form/InsertAdministratorForm.java
@@ -18,6 +18,9 @@ public class InsertAdministratorForm {
 	/** パスワード */
 	@NotBlank()
 	private String password;
+	/** 確認用パスワード */
+	@NotBlank()
+	private String passwordConfirm;
 
 	public String getName() {
 		return name;
@@ -43,10 +46,22 @@ public class InsertAdministratorForm {
 		this.password = password;
 	}
 
+	public String getPasswordConfirm() {
+		return passwordConfirm;
+	}
+
+	public void setPasswordConfirm(String passwordConfirm) {
+		this.passwordConfirm = passwordConfirm;
+	}
+
 	@Override
 	public String toString() {
 		return "InsertAdministratorForm [name=" + name + ", mailAddress=" + mailAddress + ", password=" + password
-				+ "]";
+				+ ", passwordConfirm=" + passwordConfirm + "]";
 	}
+
+	
+
+	
 
 }

--- a/src/main/resources/templates/administrator/insert.html
+++ b/src/main/resources/templates/administrator/insert.html
@@ -129,6 +129,35 @@
                     </div>
                   </div>
                 </div>
+                <!-- 確認用パスワード -->
+                <div class="form-group">
+                  <div class="row">
+                    <div class="col-sm-12">
+                      <label for="password-confirm"> パスワード（確認用）: </label>
+                      <label
+                        th:errors="*{password}"
+                        class="error-messages"
+                      >
+                        パスワードを入力してください
+                      </label>
+                      <label
+                        th:text="${notConfirmPassword}"
+                        class="error-messages"
+                      >
+                      </label>
+                      <input
+                        type="password"
+                        name="password-confirm"
+                        id="password-confirm"
+                        class="form-control"
+                        placeholder="password"
+                        th:field="*{passwordConfirm}"
+                        th:errorclass="error-input"
+                        value="xxxxxxxx"
+                      />
+                    </div>
+                  </div>
+                </div>
                 <!-- 登録ボタン -->
                 <div class="form-group">
                   <div class="row">


### PR DESCRIPTION
(1-4)はすでに登録後にリダイレクトするようにしていたので省略します。

管理者登録時に再確認用パスワードを求める機能を追加しました。
1.管理者登録用のFormクラスにpasswordConfirmフィールドを追加（NotBlank）
2.html側でinputを増設
3.Controllerでパスワードが一致しているか確認してから、登録処理に流れるよう変更
4.パスワードが異なっていた場合はリクエストスコープにメッセージを格納し、管理者登録画面へフォワード